### PR TITLE
Update image tag to v99

### DIFF
--- a/gitops/workloads/imagepull-demo/kustomization.yaml
+++ b/gitops/workloads/imagepull-demo/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 
 images:
   - name: nginx
-    newTag: 1.29.1-alpine
+    newTag: v99
 


### PR DESCRIPTION
## Pod Troubleshooting Fix

This PR updates the image tag in the imagepull-demo workload.

### Changes
- Updated `newTag` to `v99` in `gitops/workloads/imagepull-demo/kustomization.yaml`

### Context
- Automated fix for pod issues
- Generated by k8s-ai-agent

### Review Required
Please review and merge if the changes look correct.