### PR TITLE
Update image tag to 1.29.1-alpine

### DIFF
--- a/gitops/workloads/imagepull-demo/kustomization.yaml
+++ b/gitops/workloads/imagepull-demo/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
 - name: nginx
-  newTag: v99
+  newTag: 1.29.1-alpine


### PR DESCRIPTION
## Pod Troubleshooting Fix

This PR updates the image tag in the imagepull-demo workload.

### Changes
- Updated `newTag` to `1.29.1-alpine` in `gitops/workloads/imagepull-demo/kustomization.yaml`

### Context
- Automated fix for pod issues
- Generated by k8s-ai-agent

### Review Required
Please review and merge if the changes look correct.