### PR TITLE
Update image tag to v1.98

### DIFF
--- a/gitops/workloads/imagepull-demo/kustomization.yaml
+++ b/gitops/workloads/imagepull-demo/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
 - name: nginx
-  newTag: v1.98
+  newTag: "v1.98"

--- a/gitops/workloads/imagepull-demo/kustomization.yaml
+++ b/gitops/workloads/imagepull-demo/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 
 images:
 - name: nginx
-  newTag: "1.27.2-alpine"
+  newTag: v1.98


### PR DESCRIPTION
## Pod Troubleshooting Fix

This PR updates the image tag in the imagepull-demo workload.

### Changes
- Updated `newTag` to `v1.98` in `gitops/workloads/imagepull-demo/kustomization.yaml`

### Context
- Automated fix for pod issues
- Generated by k8s-ai-agent

### Review Required
Please review and merge if the changes look correct.